### PR TITLE
dhcrelay[6] - endless loop fix

### DIFF
--- a/usr.sbin/dhcrelay/bpf.c
+++ b/usr.sbin/dhcrelay/bpf.c
@@ -429,6 +429,13 @@ receive_packet(struct interface_info *interface, unsigned char *buf,
 		 * do is drop it.
 		 */
 		if (hdr.bh_caplen != hdr.bh_datalen) {
+			/*
+			 * Always bail when we would end up in an endless loop.
+			 * if both rbuf_offset and rbuf_len do not change, will will asess the same
+			 * situation in the next iteration.
+			 */
+			if (hdr.bh_caplen == 0)
+				break;
 			interface->rbuf_offset += hdr.bh_hdrlen =
 			    hdr.bh_caplen;
 			continue;

--- a/usr.sbin/dhcrelay6/bpf.c
+++ b/usr.sbin/dhcrelay6/bpf.c
@@ -360,6 +360,14 @@ receive_packet(struct interface_info *interface, unsigned char *buf,
 		 * do is drop it.
 		 */
 		if (hdr.bh_caplen != hdr.bh_datalen) {
+			/*
+			 * Always bail when we would end up in an endless loop.
+			 * if both rbuf_offset and rbuf_len do not change, will will asess the same
+			 * situation in the next iteration.
+			 */
+			if (hdr.bh_caplen == 0)
+				break;
+
 			interface->rbuf_offset += hdr.bh_hdrlen =
 			    hdr.bh_caplen;
 			continue;


### PR DESCRIPTION
when the captured portion of the packet (bh_caplen) equals 0 and the length of the packet off the wire (bh_datalen) doesn't equal 0, we will loop forever in receive_packet()

should fix https://github.com/opnsense/core/issues/7471